### PR TITLE
added checkbox for appAutomation, default webAutomation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
 
 group = 'org.jenkins-ci.plugins'
 
-version = '1.20.7'
+version = '1.20.8'
 
 description = 'LambdaTest Plugin is used to run automated selenium tests on LambdaTest Cloud'
 

--- a/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
@@ -61,6 +61,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 	private String tunnelExtCommand;
 	private Process tunnelProcess;
 	private UserAuthResponse userAuthResponse;
+	private boolean appAutomation;
 	
 	//To Save Download Tunnel location
 	private String downloadTunnelPath;
@@ -71,7 +72,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 	
 	@DataBoundConstructor
 	public MagicPlugBuildWrapper(StaplerRequest req, @CheckForNull List<JSONObject> seleniumCapabilityRequest, @CheckForNull List<JSONObject> appAutomationCapabilityRequest,
-			@CheckForNull String credentialsId, String choice, boolean useLocalTunnel, LocalTunnel localTunnel,
+			@CheckForNull String credentialsId, String choice, boolean useLocalTunnel, boolean appAutomation, LocalTunnel localTunnel,
 			ItemGroup context) throws Exception {
 		try {
 			choice = "prod";
@@ -91,6 +92,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 			}
 			// Setting up credentials in both case if input capabilities are there or not
 			this.choice = choice;
+			this.appAutomation = appAutomation;
 			setLambdaTestCredentials(credentialsId, context);
 			setCredentialsId(credentialsId);
 			if (localTunnel != null) {
@@ -174,7 +176,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 		// Create Grid URL
 		if (!CollectionUtils.isEmpty(seleniumCapabilityRequest)) {
 			this.gridURL = CapabilityService.buildHubURL(this.username, this.accessToken.getEncryptedValue(),"production");
-		} else if (!CollectionUtils.isEmpty(appAutomationCapabilityRequest)) {
+		} else if (!CollectionUtils.isEmpty(appAutomationCapabilityRequest) || this.appAutomation) {
 			logger.info("appAutomationCR : " + appAutomationCapabilityRequest);
 			this.gridURL = AppAutomationCapabilityService.appAutomationBuildHubURL(this.username, this.accessToken.getEncryptedValue(),"production");
 		}
@@ -235,6 +237,9 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 			env.put(Constant.LT_BROWSERS, createBrowserJSON(seleniumCapabilityRequest));
 			env.put(Constant.LT_BRANDS, createBrandJSON(appAutomationCapabilityRequest));
 			env.put(Constant.LT_DEVICES, createDeviceJSON(appAutomationCapabilityRequest));
+			if (gridURL == null){
+				gridURL = CapabilityService.buildHubURL(username, accessToken.getEncryptedValue(),"production");
+			}
 			env.put(Constant.LT_GRID_URL, gridURL);
 			env.put(Constant.LT_BUILD_NAME, buildname);
 			env.put(Constant.LT_BUILD_NUMBER, buildnumber);
@@ -528,6 +533,13 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 
 	public void setUseWorkspacePath(boolean useWorkspacePath) {
 		this.useWorkspacePath = useWorkspacePath;
+	}
+
+	public boolean isAppAutomation() {
+		return appAutomation;
+	}
+	public void setAppAutomation(boolean appAutomation) {
+		this.appAutomation = appAutomation;
 	}
 
 	

--- a/src/main/java/com/lambdatest/jenkins/freestyle/report/AppAutomationReportBuildAction.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/report/AppAutomationReportBuildAction.java
@@ -62,7 +62,7 @@ public class AppAutomationReportBuildAction extends AbstractAppAutomationReportB
                     if (buildDetailNode.get("name").toString().replaceAll("\"", "").equals(buildName)) {
                         String build_id = buildDetailNode.get("build_id").toString();
 
-                        lambdaTestBuildDeviceUrl = Constant.APP_AUTOMATION_APP_URL + "/test?buildid=" + build_id;
+                        lambdaTestBuildDeviceUrl = "https://appautomation.lambdatest.com/build/?searchtxt=" + build_id;
 
                         logger.info("lambdaTestBuildDeviceUrl : " + lambdaTestBuildDeviceUrl);
                         URL sessionUrl = new URL(Constant.AppAutomationReport.SESSION_INFO_URL + "?limit=100&build_id=" + build_id);
@@ -136,7 +136,7 @@ public class AppAutomationReportBuildAction extends AbstractAppAutomationReportB
         return result;
     }
 
-    public String getLambdaTestBuilddeviceUrl() {
+    public String getLambdaTestBuildDeviceUrl() {
         return lambdaTestBuildDeviceUrl;
     }
 

--- a/src/main/java/com/lambdatest/jenkins/freestyle/report/ReportBuildAction.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/report/ReportBuildAction.java
@@ -39,6 +39,8 @@ public class ReportBuildAction extends AbstractReportBuildAction {
         String authStringEnc = new String(authEncBytes);
         logger.info("in generate generateLambdaTestReport function");
         try {
+            // Add a 5-second sleep
+            Thread.sleep(5000);
             URL buildUrl = new URL(Constant.Report.BUILD_INFO_URL);
             URLConnection buildUrlConnection = buildUrl.openConnection();
             buildUrlConnection.setRequestProperty("Authorization", "Basic " + authStringEnc);
@@ -61,8 +63,7 @@ public class ReportBuildAction extends AbstractReportBuildAction {
                     if (buildDetailNode.get("name").toString().replaceAll("\"", "").equals(buildName)) {
                         String build_id = buildDetailNode.get("build_id").toString();
 
-                        lambdaTestBuildBrowserUrl = "https://automation.lambdatest.com/logs/?build=" + build_id;
-
+                        lambdaTestBuildBrowserUrl = "https://automation.lambdatest.com/build?&build=" + build_id;
                         logger.info("lambdaTestBuildBrowserUrl : " + lambdaTestBuildBrowserUrl);
                         URL sessionUrl = new URL(Constant.Report.SESSION_INFO_URL + "?limit=100&build_id=" + build_id);
                         URLConnection sessionUrlConnection = sessionUrl.openConnection();
@@ -96,7 +97,12 @@ public class ReportBuildAction extends AbstractReportBuildAction {
                             }
                             resultJSON.put("browserVersion",sessionDetailNode.get("version").toString().replaceAll("\"", ""));
                             resultJSON.put("OS",sessionDetailNode.get("platform").toString().replaceAll("\"", ""));
-                            resultJSON.put("name",sessionDetailNode.get("name").toString().replaceAll("\"", ""));
+                            
+                            if(sessionDetailNode.has("name")) {
+                                resultJSON.put("name",sessionDetailNode.get("name").toString().replaceAll("\"", ""));
+                            } else {
+                                resultJSON.put("name",sessionDetailNode.get("test_id").toString().replaceAll("\"", ""));
+                            }
                             resultJSON.put("testId",sessionDetailNode.get("test_id").toString().replaceAll("\"", ""));
                             resultJSON.put("testDuration",sessionDetailNode.get("duration").toString().replaceAll("\"", ""));
                             resultJSON.put("createdAtReadable",sessionDetailNode.get("create_timestamp").toString().replaceAll("\"", ""));
@@ -122,6 +128,9 @@ public class ReportBuildAction extends AbstractReportBuildAction {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
+        } catch (InterruptedException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
         }
     }
 

--- a/src/main/resources/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper/config.jelly
+++ b/src/main/resources/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper/config.jelly
@@ -50,6 +50,9 @@
 			</f:repeatable>
 		</f:entry>
 		<f:entry title="Real Device App Automation Tests">
+			 <f:entry title="Enable App Automation" field="appAutomation">
+        		<f:checkbox checked="${instance.appAutomation}"/>
+    		</f:entry>
 			<f:repeatable var="appAutomationCapabilityRequest" items="${instance.appAutomationCapabilityRequest}"  add="Add App Automation Test Capability">
 				<table width="100%">
 					<f:entry title="Platform Name" field="platformName">

--- a/src/main/resources/com/lambdatest/jenkins/freestyle/report/AbstractAppAutomationReportBuildAction/index.jelly
+++ b/src/main/resources/com/lambdatest/jenkins/freestyle/report/AbstractAppAutomationReportBuildAction/index.jelly
@@ -108,7 +108,7 @@
                 <div style="border-style: solid;border-width: thin;">
                     <div align="center">
                         <h3>
-                            Build Name: <a href="${it.lambdaTestBuildBrowserUrl}" target="_blank">${it.buildName}</a>
+                            Build Name: <a href="${it.lambdaTestBuildDeviceUrl}" target="_blank">${it.buildName}</a>
                          </h3>
                     </div>
                 </div>


### PR DESCRIPTION
Added appAutomation checkbox to select for appAutomation grid URL, webAutomation has been made a default choice.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
