### PR TITLE
Tunnel force stop addition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
 
 group = 'org.jenkins-ci.plugins'
 
-version = '1.21.5'
+version = '1.21.6'
 
 description = 'LambdaTest Plugin is used to run automated selenium tests on LambdaTest Cloud'
 

--- a/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
@@ -311,12 +311,11 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 			try {
 				logger.info("tearDown");
 				int result = stopTunnel(buildnumber, build.getWorkspace());
-		
-				if (result == -1) {
-					logger.info("Tunnel was not active.");
-				} else {
-					logger.info("Tunnel stopped successfully.");
+				if (result<0 && tunnelProcess != null && tunnelProcess.isAlive()){
+					logger.info("Tunnel is still active, forcefully tearing down the tunnel process.");
+					tunnelProcess.destroy();
 				}
+				logger.info("Tunnel stopped successfully.");
 			} catch (Exception e) {
 				logger.warning("Forcefully Tear Down due to: " + e.getMessage());
 				if (tunnelProcess != null && tunnelProcess.isAlive()) {
@@ -366,7 +365,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 				return 10;
 			} else {
 				logger.info("Tunnel Stopped");
-				return -1;
+				return 0;
 			}
 		}
 		


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->


This pull request updates the `MagicPlugBuildWrapper` class to improve the handling of the tunnel teardown process in Jenkins builds. The changes ensure better reliability when stopping the tunnel and provide more accurate status codes.

### Improvements to tunnel teardown process:

* `tearDown` method in `MagicPlugBuildWrapper.java`:
  - Added logic to forcefully terminate the tunnel process if it is still active after an attempt to stop it. This ensures that lingering processes are properly cleaned up.
  - Adjusted logging to reflect the successful stopping of the tunnel after handling active processes.

* `stopTunnel` method in `MagicPlugBuildWrapper.java`:
  - Changed the return value to `0` instead of `-1` when the tunnel stops successfully, standardizing the status code to align with typical success conventions.