### PR TITLE
fix: hub URL credential + mask access token in console (release 1.21.8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
 
 group = 'org.jenkins-ci.plugins'
 
-version = '1.21.7'
+version = '1.21.8'
 
 description = 'LambdaTest Plugin is used to run automated selenium tests on LambdaTest Cloud'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.21.7
+version=1.21.8

--- a/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
@@ -192,9 +192,9 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 
 		// Create Grid URL
 		if (!CollectionUtils.isEmpty(seleniumCapabilityRequest)) {
-			this.gridURL = CapabilityService.buildHubURL(this.username, this.accessToken.getEncryptedValue(),"production");
+			this.gridURL = CapabilityService.buildHubURL(this.username, this.accessToken.getPlainText(),"production");
 		} else if (!CollectionUtils.isEmpty(appAutomationCapabilityRequest) || this.appAutomation) {
-			this.gridURL = AppAutomationCapabilityService.appAutomationBuildHubURL(this.username, this.accessToken.getEncryptedValue(),"production");
+			this.gridURL = AppAutomationCapabilityService.appAutomationBuildHubURL(this.username, this.accessToken.getPlainText(),"production");
 		}
 		return new MagicPlugEnvironment(build);
 	}
@@ -286,7 +286,7 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 			env.put(Constant.LT_BRANDS, createBrandJSON(appAutomationCapabilityRequest));
 			env.put(Constant.LT_DEVICES, createDeviceJSON(appAutomationCapabilityRequest));
 			if (gridURL == null){
-				gridURL = CapabilityService.buildHubURL(username, accessToken.getEncryptedValue(),"production");
+				gridURL = CapabilityService.buildHubURL(username, accessToken.getPlainText(),"production");
 			}
 			env.put(Constant.LT_GRID_URL, gridURL);
 			env.put(Constant.LT_BUILD_NAME, buildname);

--- a/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/MagicPlugBuildWrapper.java
@@ -3,11 +3,13 @@ package com.lambdatest.jenkins.freestyle;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
@@ -46,6 +48,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.ItemGroup;
+import hudson.model.Run;
 import hudson.tasks.BuildWrapper;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
@@ -197,6 +200,25 @@ public class MagicPlugBuildWrapper extends BuildWrapper implements Serializable 
 			this.gridURL = AppAutomationCapabilityService.appAutomationBuildHubURL(this.username, this.accessToken.getPlainText(),"production");
 		}
 		return new MagicPlugEnvironment(build);
+	}
+
+	@Override
+	public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
+		sensitiveVariables.add(Constant.LT_ACCESS_KEY);
+		sensitiveVariables.add(Constant.LT_GRID_URL);
+	}
+
+	@Override
+	public OutputStream decorateLogger(AbstractBuild build, OutputStream logger)
+			throws IOException, InterruptedException, Run.RunnerAbortedException {
+		if (this.accessToken == null) {
+			return logger;
+		}
+		String secret = this.accessToken.getPlainText();
+		if (secret == null || secret.isEmpty()) {
+			return logger;
+		}
+		return new SecretMaskingOutputStream(logger, secret);
 	}
 
 	private boolean stopTunnelViaInfoAPI() {

--- a/src/main/java/com/lambdatest/jenkins/freestyle/SecretMaskingOutputStream.java
+++ b/src/main/java/com/lambdatest/jenkins/freestyle/SecretMaskingOutputStream.java
@@ -1,0 +1,47 @@
+package com.lambdatest.jenkins.freestyle;
+
+import hudson.console.LineTransformationOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Wraps a build's console OutputStream so that any occurrence of the
+ * provided secret is replaced with {@code ****} before reaching the log.
+ */
+class SecretMaskingOutputStream extends LineTransformationOutputStream {
+
+	private static final String MASK = "****";
+
+	private final OutputStream out;
+	private final String secret;
+
+	SecretMaskingOutputStream(OutputStream out, String secret) {
+		this.out = out;
+		this.secret = secret;
+	}
+
+	@Override
+	protected void eol(byte[] b, int len) throws IOException {
+		if (secret == null || secret.isEmpty()) {
+			out.write(b, 0, len);
+			return;
+		}
+		String line = new String(b, 0, len, StandardCharsets.UTF_8);
+		String redacted = line.replace(secret, MASK);
+		out.write(redacted.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Override
+	public void flush() throws IOException {
+		super.flush();
+		out.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		super.close();
+		out.close();
+	}
+}


### PR DESCRIPTION
## Summary

Two-layer fix for the credential-in-hub-URL bug reported by customers running Jenkins jobs that consume the `LT_GRID_URL` environment variable.

**Layer 1 (correctness):** `MagicPlugBuildWrapper` was passing `Secret#getEncryptedValue()` into the hub URL builder. That returns the Jenkins-internal `{AQAAA...}` envelope, which contains `{` and `}` — characters that are not allowed in a URI authority component per RFC 3986. The resulting `LT_GRID_URL` (e.g. `https://USER:{AQAAA...}@hub.lambdatest.com/wd/hub`) cannot be parsed by `java.net.URI` and any test code that does so fails with:

```
java.net.URISyntaxException: Illegal character in authority at index 8:
  https://USER:{AQAAA...}@hub.lambdatest.com/wd/hub
```

This affects every release from **1.20.6** (Sep 2023) through **1.21.7** (current). The change was introduced in commit `0d899eb` ("comment fixes and tunnel stop changes") in PR #20 — a reviewer asked to stop logging the plaintext access token, and the author addressed it by encrypting the value going into the URL itself rather than the value being logged. The duplicate log line was also removed in the same diff, so the original concern (plaintext in logs) was already separately resolved.

This PR reverts those three call sites to `getPlainText()`, restoring valid URI semantics for `LT_GRID_URL`.

**Layer 2 (defense in depth):** Restoring plaintext to the URL means the access token is now visible in the runtime env var, just as it has always been in `LT_ACCESS_KEY`. To minimise visibility-change risk for users whose pipelines log or print `LT_GRID_URL`, this PR also adds Jenkins's standard secret-masking hooks:

- `makeSensitiveBuildVariables`: marks `LT_ACCESS_KEY` and `LT_GRID_URL` as sensitive so the build's Environment Variables UI page shows them as `[redacted]`.
- `decorateLogger`: wraps the build's console `OutputStream` with a `LineTransformationOutputStream` that replaces the access token's plaintext with `****` line by line. So even if a user pipeline does `echo $LT_GRID_URL` the build console shows `https://USER:****@hub.lambdatest.com/wd/hub`.

This uses APIs that have been on `BuildWrapper` since long before this plugin's `Jenkins-Version: 2.120` floor and is the same pattern used by the Credentials Binding and Mask Passwords plugins.

## Commits

1. **`fix: use Secret#getPlainText() for hub URL credential`** — three-line revert at `MagicPlugBuildWrapper.java:195, 197, 289`.
2. **`chore: bump version to 1.21.8`** — `gradle.properties` and `build.gradle` bumped together to keep the two version sources in sync.
3. **`feat: mask access token in build console + mark env vars sensitive`** — adds `SecretMaskingOutputStream` (47 lines) and overrides `makeSensitiveBuildVariables` and `decorateLogger` on `MagicPlugBuildWrapper` (22 lines).

## Why this is safe

- `gridURL` is a transient runtime field (no `@DataBoundSetter`, not in `config.jelly`) — never persisted to `config.xml`.
- The masking layer passes through unchanged when `accessToken` is null or empty, so wrappers without a credential behave exactly as before.
- `String.replace(CharSequence, CharSequence)` does not use regex, so secret values containing regex meta-characters work safely.
- Multi-byte UTF-8 line content (verified with Japanese, arrows, stars) round-trips correctly through `LineTransformationOutputStream`.
- The two new overrides on `BuildWrapper` are pure additions — the base-class implementations are no-ops, so we cannot regress any existing behaviour.

## Reproduction & verification

Tested against the affected customer environment (Jenkins 2.303.2 + JDK 8) by deploying the patched HPI to `jenkins/jenkins:2.303.2-jdk8` and running a comprehensive test script via Jenkins's script console. All tests on the live container passed:

| Test | Result |
| --- | --- |
| `decorateLogger` returns `SecretMaskingOutputStream` for valid secret | ✅ |
| Console output with the access token is masked to `****` | ✅ |
| Build name and other non-secret content survives masking | ✅ |
| `decorateLogger` with NULL `accessToken` returns the original logger | ✅ |
| `decorateLogger` with EMPTY secret returns the original logger (no corruption) | ✅ |
| `makeSensitiveBuildVariables` adds `LT_ACCESS_KEY` and `LT_GRID_URL` to the set | ✅ |
| Performance: 10,000 lines masked in ~140ms (~14μs/line) | ✅ |
| Multi-byte UTF-8 content (Japanese, arrows, stars) preserved across masking | ✅ |
| `CapabilityService.buildHubURL(plaintext)` produces a parseable URI | ✅ |
| `CapabilityService.buildHubURL(encrypted)` reproduces the customer's `URISyntaxException` | ✅ |
| End-to-end: reflectively-allocated `MagicPlugBuildWrapper` produces a parseable `LT_GRID_URL` | ✅ |

## Test plan

- [x] Built locally with JDK 8 (project's `targetCompatibility = 1.8`)
- [x] HPI manifest confirms `Plugin-Version: 1.21.8`
- [x] Patched HPI installs cleanly on `jenkins/jenkins:2.303.2-jdk8` and `jenkins/jenkins:2.303.2-lts-jdk11`
- [x] Live bytecode verification: zero `getEncryptedValue` references in `MagicPlugBuildWrapper.class`
- [x] All masking edge cases verified on the live container (see table above)

## Known limitations (separate follow-ups, not blocking)

- The `AnalyticRequest` POST to `backend.lambdatest.com/api/analytics/automation-plugin-usage` (line 296) still includes the credentialed URL as part of its payload. This is unchanged by this PR (was sending the encrypted blob before, sends plaintext URL now — either way it's a credential exposure) and should be addressed in a separate PR by stripping `userInfo` from the URL before serialising.
- Custom file writes outside Jenkins's console-write path (e.g. `printenv > /tmp/dump.txt` in a build step) cannot be intercepted by `decorateLogger` and will still see plaintext credentials. This is fundamentally outside the plugin's control and should be communicated in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)